### PR TITLE
Fix inheritance Bug in sentinelone_policy module 

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Perform sanity testing with ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ Sva.Sentinelone Release Notes
 .. contents:: Topics
 
 
+v1.0.1
+======
+
+Release Summary
+---------------
+
+This is a bugfix release
+
+Bugfixes
+--------
+
+- sentinelone_policies module: When a group policy inherited from the site area was updated with a custom setting, all other settings were reset to the default values. Now the inherited settings are updated by the settings passed to the module and the other inherited settings are retained.
+
 v1.0.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ This is a bugfix release
 Bugfixes
 --------
 
-- sentinelone_policies module: When a group policy inherited from the site area was updated with a custom setting, all other settings were reset to the default values. Now the inherited settings are updated by the settings passed to the module and the other inherited settings are retained.
+- sentinelone_policies module: When a group policy inherited from the site scope was updated with a custom setting, all other settings were reset to the default values. Now the inherited settings are updated by the settings passed to the module and the other inherited settings are retained.
 
 v1.0.0
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -32,7 +32,7 @@ releases:
     changes:
       bugfixes:
       - 'sentinelone_policies module: When a group policy inherited from the site
-        area was updated with a custom setting, all other settings were reset to the
+        scope was updated with a custom setting, all other settings were reset to the
         default values. Now the inherited settings are updated by the settings passed
         to the module and the other inherited settings are retained.'
       release_summary: 'This is a bugfix release'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -28,3 +28,14 @@ releases:
       name: sentinelone_upgrade_policies
       namespace: ''
     release_date: '2022-08-16'
+  1.0.1:
+    changes:
+      bugfixes:
+      - 'sentinelone_policies module: When a group policy inherited from the site
+        area was updated with a custom setting, all other settings were reset to the
+        default values. Now the inherited settings are updated by the settings passed
+        to the module and the other inherited settings are retained.'
+      release_summary: 'This is a bugfix release'
+    fragments:
+    - v1.0.1.yaml
+    release_date: '2023-01-30'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: "sva"
 name: "sentinelone"
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.0.0"
+version: "1.0.1"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: "README.md"

--- a/plugins/modules/sentinelone_policies.py
+++ b/plugins/modules/sentinelone_policies.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -248,28 +249,23 @@ class SentinelonePolicies(SentineloneBase):
         return response
 
     @staticmethod
-    def get_update_body(current_settings: dict, desired_state_settings: dict):
+    def get_update_body(policy_settings: dict):
         """
-        Create post object. Wrapping settings in data dictionary and check for autoMitigationAction
+        Prepare the merged object for post request
 
-        :param current_settings: current policy settings
-        :type current_settings: dict
-        :param desired_state_settings: settings which should be ensured
-        :type desired_state_settings: dict
+        :param policy_settings: desired state policy settings
+        :type policy_settings: dict
         :return: update body for API
         :rtype: dict
         """
 
-        desired_state_policy_body = {
-            "data": desired_state_settings
-        }
+        # Remove deprecated policy settings. The module would not work correctly in some circumstances
+        del policy_settings['agentNotification']
+        del policy_settings['agentUiOn']
 
-        # API call will fail if autoMitigationAction is not set in update body. So we make shure it is set. And use the
-        # current setting if neccessary
-        if desired_state_policy_body['data'].get('autoMitigationAction', None) is None:
-            desired_state_policy_body['data']['autoMitigationAction'] = current_settings['data']['autoMitigationAction']
+        policy_object = {'data': policy_settings}
 
-        return desired_state_policy_body
+        return policy_object
 
 
 def run_module():
@@ -311,13 +307,13 @@ def run_module():
                 # check if every group has the desired settings already
                 current_policy = policy_obj.get_current_policy(current_group_id, module)
                 desired_state_policy = policy_obj.desired_state_policy
-                diff = policy_obj.merge_compare(current_policy['data'], desired_state_policy)[0]
+                diff, merged_policy = policy_obj.merge_compare(current_policy['data'], desired_state_policy)
                 if diff:
                     # if group policy is different from desired state, update it
                     current_group_name = current_group_id_name[1]
                     diffs.append({'changes': dict(diff), 'groupId': current_group_id})
                     basic_message.append(f"Updating policy for group {current_group_name}")
-                    update_body = policy_obj.get_update_body(current_policy, desired_state_policy)
+                    update_body = policy_obj.get_update_body(merged_policy)
                     policy_obj.update_policy(current_group_id, update_body, module)
         else:
             # if scope is site level
@@ -326,12 +322,12 @@ def run_module():
             site_id = policy_obj.site_id
             current_policy = policy_obj.get_current_policy(site_id, module)
             desired_state_policy = policy_obj.desired_state_policy
-            diff = policy_obj.merge_compare(current_policy['data'], desired_state_policy)[0]
+            diff, merged_policy = policy_obj.merge_compare(current_policy['data'], desired_state_policy)
             if diff:
                 # if site policy is different from desired state, update it
                 diffs.append({'changes': dict(diff), 'SiteId': site_id})
                 basic_message.append(f"Updating policy for site {site_name}")
-                update_body = policy_obj.get_update_body(current_policy, desired_state_policy)
+                update_body = policy_obj.get_update_body(merged_policy)
                 policy_obj.update_policy(site_id, update_body, module)
     else:
         # if we want to enable inheritance

--- a/plugins/modules/sentinelone_policies.py
+++ b/plugins/modules/sentinelone_policies.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import (absolute_import, division, print_function)
-
 __metaclass__ = type
 
 DOCUMENTATION = r'''


### PR DESCRIPTION
When a group policy inherited from the site scope was updated with a custom setting, all other settings were reset to the default values.
Now the inherited settings are updated by the settings passed to the module and the other inherited settings are retained.
