### PR TITLE
Added become: true to neccessary tasks

### DIFF
--- a/roles/install_agent/README.md
+++ b/roles/install_agent/README.md
@@ -44,6 +44,13 @@ You need to provide the gpg key to validate the package signatures correctly. Yo
 
 Place the key on the host executing the Playbook and adjust the `gpg_key` variable accordingly.
 
+Required for .deb based systems.
+Required for .rpm based systems when agent version >= 23.3.2.12.
+
+### Become user
+**Linux:** On the control-node, where the playbook is executed, only user permissions are required. On the remote node you have to provide a become user since some tasks need to run as root. Either provide a _become_user_ on playbook or _include_role_ task scope or set the variable _ansible_become_user_ accordingly. The remote user must be configured with sudo permissions or other privilege escalation methods.
+
+**Windows:** _ansible_user_ has to be an administrator account. Therefore no privilege escalation is needed.
 
 Role Variables
 --------------
@@ -55,7 +62,7 @@ Role Variables
 | `console_url` | https://my-console.sentinelone.net | The URL of the SentinelOne Management Console |
 | `api_token` | XXXXXXXXXXXXXXXXXX | The API token for the API user for authentication |
 | `site` | prod | The site to which the new hosts should be assigned |
-| `gpg_key` | /tmp/sentinel_one.gpg | Only required on **Linux** agents. Path to the gpg key which will be installed and used for package signature verification |
+| `gpg_key` | /tmp/sentinel_one.gpg | **Linux** only. Required for .deb based systems. Required for .rpm based systems when agent version >= 23.3.2.12. Path to the gpg key which will be installed and used for package signature verification |
 
 ### Optional Variables
 

--- a/roles/install_agent/tasks/Linux.yml
+++ b/roles/install_agent/tasks/Linux.yml
@@ -5,11 +5,11 @@
 
 - name: "Linux Block: Skip if sentinelagent is already installed."
   when: not agent_installed
+  become: true
   block:
     - name: Get dmesg output
       ansible.builtin.command: dmesg
       changed_when: false
-      become: true
       register: dmesg_output
 
     - name: Assert that no function tracing issues occured
@@ -80,6 +80,7 @@
     # \\s needed because yaml interprets \s as escape sequence
     cmd: "set -o pipefail && /opt/sentinelone/bin/sentinelctl management status | grep -E '^Connectivity\\s+(On|Off)$' | awk '{ print $2 }'"
     executable: "/bin/bash"
+  become: true
   register: agent_status
   failed_when: agent_status.stdout is not regex("On|Off")
   changed_when: agent_status.stdout is not regex("On|Off")
@@ -87,6 +88,7 @@
 - name: "Linux: Register agent"
   ansible.builtin.command:
     cmd: '/opt/sentinelone/bin/sentinelctl management token set {{ reg_token_obj.json.data.token }}'
+  become: true
   register: token_set_output
   no_log: "{{ hide_sensitive }}"
   failed_when: '"Registration token successfully set" not in token_set_output.stdout'
@@ -97,14 +99,17 @@
     name: sentinelone
     state: started
     enabled: true
+  become: true
 
 - name: "Linux: Remove agent install package from target machine"
   ansible.builtin.file:
     path: "{{ remote_pkg_path }}"
     state: absent
+  become: true
   when: not agent_installed
 
 - name: "Linux: Remove gpg key from target machine"
   ansible.builtin.file:
     path: "{{ remote_gpg_key_path }}"
     state: absent
+  become: true

--- a/roles/install_agent/tasks/main.yml
+++ b/roles/install_agent/tasks/main.yml
@@ -12,6 +12,7 @@
 - name: "Linux: Install python bindings for package managers"
   ansible.builtin.package:
     name: "{{ 'python3-rpm' if ansible_facts.os_family == 'Suse' else 'python-apt-common' }}"
+  become: true
   when: ansible_facts.os_family == 'Suse' or ansible_facts.os_family == 'Debian'
 
 - name: "Linux: Gather package facts"
@@ -121,7 +122,6 @@
     state: absent
   delegate_to: localhost
   when: not agent_installed
-
 
 - name: "Fail if new client does not appear in management console"
   ansible.builtin.uri:


### PR DESCRIPTION
As in https://github.com/svalabs/sva.sentinelone/issues/30 described, in an environment where the local user has no root privileges but the remote user has, the playbook will fail if executed with _become: true_ globally.

This PR fixes this issue. It adds the _become_ statement to neccessary remote tasks.