### PR TITLE
add legacy roles fixes from upstream role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tests/output/
 .idea/
 .vscode/
+.lock

--- a/roles/sentinelone_client_legacy/handlers/main.yml
+++ b/roles/sentinelone_client_legacy/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create initialization file
   ansible.builtin.file:
-    path: /opt/sentinelone/.INITIALIZATION_COMPLETE
+    path: /opt/.SENTINELTWO_INITIALIZATION_COMPLETE
     owner: root
     group: root
     mode: '0644'

--- a/roles/sentinelone_client_legacy/molecule/default/converge.yml
+++ b/roles/sentinelone_client_legacy/molecule/default/converge.yml
@@ -4,21 +4,21 @@
   pre_tasks:
     - name: Set SentinelONE client installation file (Debian)
       ansible.builtin.set_fact:
-        file_sentinelone: sentinelone_latest.deb
+        sentinelone_client_legacy_file: sentinelone_latest.deb
       when: ansible_os_family == 'Debian'
 
     - name: Set SentinelONE client installation file (Red Hat)
       ansible.builtin.set_fact:
-        file_sentinelone: sentinelone_latest.rpm
+        sentinelone_client_legacy_file: sentinelone_latest.rpm
       when: ansible_os_family == 'RedHat'
 
     - name: Set SentinelONE client installation file (SUSE)
       ansible.builtin.set_fact:
-        file_sentinelone: sentinelone_latest.rpm
+        sentinelone_client_legacy_file: sentinelone_latest.rpm
       when: ansible_os_family == 'Suse'
 
   roles:
     - role: sva.sentinelone.sentinelone_client_legacy
-      sentinelone_client_filename: "{{ file_sentinelone }}"
+      sentinelone_client_filename: "{{ sentinelone_client_legacy_file }}"
       # sentinelone_client_token: '...'
       # sentinelone_client_gpgkey: '...'

--- a/roles/sentinelone_client_legacy/tasks/main.yml
+++ b/roles/sentinelone_client_legacy/tasks/main.yml
@@ -18,7 +18,7 @@
   ansible.builtin.get_url:
     url: "{{ sentinelone_client_filename }}"
     dest: "/tmp/{{ sentinelone_client_filename | basename }}"
-    mode: "0644"
+    mode: '0644'
   when: "'http' in sentinelone_client_filename"
 
 - name: Copy installation package

--- a/roles/sentinelone_client_legacy/tasks/main.yml
+++ b/roles/sentinelone_client_legacy/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Set Group/Site token
   ansible.builtin.command: "/opt/sentinelone/bin/sentinelctl management token set {{ sentinelone_client_token }}"
   args:
-    creates: /opt/sentinelone/.INITIALIZATION_COMPLETE
+    creates: /opt/.SENTINELTWO_INITIALIZATION_COMPLETE
   become: true
   notify: Create initialization file
   when: sentinelone_client_token is defined and sentinelone_client_token != ''


### PR DESCRIPTION
This also adds a crucial fix that prevented the installation on some Linux distributions because of a lock file in the agent installation path