### PR TITLE
Fixes several bugs with the install_agent role

### DIFF
--- a/roles/install_agent/README.md
+++ b/roles/install_agent/README.md
@@ -18,11 +18,12 @@ Requirements
 An API key is required to use this role unless both `custom_client_url` and `registration_token` are set (see [API-less installation](#api-less-installation-no-api-token-required)). It is considered best practice to create a specific 'API user' role for this purpose.
 
 The API user requires the following permissions:
-- Read site info
-- Read group info (if the scope is set to group)
-- Download agent packages
-- Read the site or group registration token
-- Read agent information
+- Endpoints -> View
+- Accounts -> View
+- Agent Packages -> View
+- Groups -> View (If the scope is set to "group")
+- Roles -> View
+- Sites -> View
 
 ### GPG Key (rpm-based linux only)
 The GPG key is used to validate the package signatures. If the `gpg_key` variable is not provided, the role will **automatically download** the required key. You can optain the key from the SentinelOne Help page ("**How to Install on a Linux Endpoint with Yum**").

--- a/roles/install_agent/tasks/main.yml
+++ b/roles/install_agent/tasks/main.yml
@@ -53,12 +53,14 @@
     custom_version: "{{ install_agent_custom_version | default(omit) }}"
   register: install_agent_return_download_agent
   delegate_to: localhost
+  become: false
   throttle: 1
   tags:
     - download_client_from_sentinel_one
   when: '(not install_agent_agent_installed) and (install_agent_custom_client_url | length == 0)'
 
 - name: "Download agent to localhost from custom source."
+  become: false
   tags:
     - download_client_from_custom_url
   when: '(not install_agent_agent_installed) and (install_agent_custom_client_url | length > 0)'
@@ -82,6 +84,7 @@
 - name: "Block: Get registration token from API"
   when: install_agent_registration_token | length == 0
   run_once: true
+  become: false
   tags:
     - sentinelone_install_agent_get_registration_token
   block:
@@ -159,6 +162,7 @@
     path: "{{ install_agent_return_download_agent.original_message.full_path }}"
     state: absent
   delegate_to: localhost
+  become: false
   when: not install_agent_agent_installed
 
 - name: "Fail if new client does not appear in management console"
@@ -175,6 +179,7 @@
     status_code: 200
   register: install_agent_registrationstatus
   delegate_to: localhost
+  become: false
   no_log: "{{ install_agent_hide_sensitive }}"
   until: ((install_agent_registrationstatus.json.data | length) > 0) and (install_agent_registrationstatus.status == 200)
   retries: "{{ install_agent_check_console_retries }}"

--- a/roles/install_agent/tasks/main.yml
+++ b/roles/install_agent/tasks/main.yml
@@ -185,4 +185,3 @@
   retries: "{{ install_agent_check_console_retries }}"
   delay: "{{ install_agent_check_console_retry_delay }}"
   when: install_agent_registration_token | length == 0
-

--- a/roles/install_agent/tasks/main.yml
+++ b/roles/install_agent/tasks/main.yml
@@ -181,7 +181,8 @@
   delegate_to: localhost
   become: false
   no_log: "{{ install_agent_hide_sensitive }}"
-  until: ((install_agent_registrationstatus.json.data | length) > 0) and (install_agent_registrationstatus.status == 200)
+  until: ((install_agent_registrationstatus.json.data | default([]) | length) > 0) and (install_agent_registrationstatus.status | default(0) == 200)
   retries: "{{ install_agent_check_console_retries }}"
   delay: "{{ install_agent_check_console_retry_delay }}"
   when: install_agent_registration_token | length == 0
+


### PR DESCRIPTION
This fixes a few things.

**Fix variable expansion when setting the endpoint URL**
Nested variable expansion does not work, so the final URL being generated still had strings like `/api/{{ siteid }}/path` in them.

**Be more specific about the API Role permissions required**
This helps to clarify the exact permissions required in the API role.

**Modernize the GPG file handling**
`apt key` is deprecated on Debian based systems. I modernized the handling of the GPG file by placing it into the `/etc/apt/trusted.gpg.d/` folder.

**Explicitly apply "become: false" for localhost tasks**
On environments where the global ansible.cfg file specifies "become: true", tasks on localhost would attempt to execute commands with `sudo` and fail.

**Prevent errors when waiting for the agent to appear**
Adds defaulting so that when authentication fails or the object returned is not in the format expected, it shows the real error instead of a parsing error.