### PR TITLE
Fixed sentinelone_download_agent example

### DIFF
--- a/plugins/modules/sentinelone_download_agent.py
+++ b/plugins/modules/sentinelone_download_agent.py
@@ -107,7 +107,7 @@ EXAMPLES = r'''
     token: "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
     os_type: "Linux"
     packet_format: "rpm"
-    download_path: "/tmp"
+    download_dir: "/tmp"
     architecture: "64_bit"
 - name: Download latest agent for linux and include EA packages
   sva.sentinelone.sentinelone_download_agent:
@@ -115,7 +115,7 @@ EXAMPLES = r'''
     token: "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
     os_type: "Linux"
     packet_format: "rpm"
-    download_path: "/tmp"
+    download_dir: "/tmp"
     architecture: "64_bit"
     agent_version: "latest_ea"
 - name: Download specific agent version


### PR DESCRIPTION
Fixes https://github.com/svalabs/sva.sentinelone/issues/64

In the example of the sentinelone_download_agent a wrong variable was used.